### PR TITLE
(openstack) boot instances from volumes

### DIFF
--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackComputeProvider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackComputeProvider.groovy
@@ -30,6 +30,15 @@ import org.openstack4j.model.compute.Server
 interface OpenstackComputeProvider {
 
   /**
+   * Get a Flavor.
+   *
+   * @param region
+   * @param flavorName
+   * @return
+   */
+  Flavor getFlavor(String region, String flavorName)
+
+  /**
    * Returns a list of instances in a given region.
    * @param region
    * @return

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackComputeV2Provider.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackComputeV2Provider.groovy
@@ -37,6 +37,13 @@ public class OpenstackComputeV2Provider implements OpenstackComputeProvider, Ope
   }
 
   @Override
+  Flavor getFlavor(String region, String flavorName) {
+    handleRequest {
+      getRegionClient(region).compute().flavors().list().find { it.name == flavorName }
+    }
+  }
+
+  @Override
   List<? extends Server> getInstances(String region) {
     handleRequest {
       getRegionClient(region).compute().servers().list()

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/servergroup/ServerGroupParameters.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/servergroup/ServerGroupParameters.groovy
@@ -51,6 +51,7 @@ class ServerGroupParameters {
   String sourceUserData
   Map<String, String> tags
   String asgResourceFilename
+  int diskSize
 
   static final ObjectMapper objectMapper = new ObjectMapper()
 
@@ -78,7 +79,8 @@ class ServerGroupParameters {
       source_user_data     : sourceUserData ?: null,
       tags                 : objectMapper.writeValueAsString(tags ?: [:]) ?: null,
       user_data            : rawUserData ?: null,
-      asg_resource_filename: asgResourceFilename ?: ServerGroupConstants.SUBTEMPLATE_FILE
+      asg_resource_filename: asgResourceFilename ?: ServerGroupConstants.SUBTEMPLATE_FILE,
+      disk_size            : diskSize ? Integer.toString(diskSize) : '40'
     ]
   }
 
@@ -110,7 +112,8 @@ class ServerGroupParameters {
       tags: unescapePythonUnicodeJsonMap(params.get('tags') ?: '{}'),
       sourceUserDataType: params.get('source_user_data_type'),
       sourceUserData: params.get('source_user_data'),
-      asgResourceFilename: params.get('asg_resource_filename')
+      asgResourceFilename: params.get('asg_resource_filename'),
+      diskSize: params.get('disk_size')?.toInteger() ?: 40
     )
   }
 

--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/DeployOpenstackAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/DeployOpenstackAtomicOperation.groovy
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.IOUtils
+import org.openstack4j.model.compute.Flavor
 import org.openstack4j.model.network.Subnet
 import org.openstack4j.model.network.ext.ListenerV2
 import org.openstack4j.model.network.ext.LoadBalancerV2
@@ -183,6 +184,9 @@ class DeployOpenstackAtomicOperation implements AtomicOperation<DeploymentResult
         task.updateStatus BASE_PHASE, "Resolved user data."
       }
 
+      //resolve flavor to use disk size
+      Flavor flav = provider.getFlavor(description.region, description.serverGroupParameters.instanceType)
+
       task.updateStatus BASE_PHASE, "Creating heat stack $stackName..."
       provider.deploy(description.region, stackName, template, subtemplates, description.serverGroupParameters.identity {
         networkId = subnet.networkId
@@ -190,6 +194,7 @@ class DeployOpenstackAtomicOperation implements AtomicOperation<DeploymentResult
         sourceUserDataType = description.userDataType
         sourceUserData = description.userData
         asgResourceFilename = resourceFilename
+        diskSize = flav.disk
         it
       }, description.disableRollback, description.timeoutMins, description.serverGroupParameters.loadBalancers)
       task.updateStatus BASE_PHASE, "Finished creating heat stack $stackName."

--- a/clouddriver-openstack/src/main/resources/asg.yaml
+++ b/clouddriver-openstack/src/main/resources/asg.yaml
@@ -16,6 +16,9 @@ parameters:
   desired_size:
     type: number
     description: Desired cluster size
+  disk_size:
+    type: number
+    description: Desired instance disk size, derived from the flavor
   network_id:
     type: string
     description: Network used by the servers. Retained for auditing purposes.
@@ -94,6 +97,7 @@ resources:
       resource:
         type: {get_param: asg_resource_filename}
         properties:
+          disk_size: {get_param: disk_size}
           flavor: {get_param: flavor}
           image: {get_param: image}
           # metering.stack is used by ceilometer to autoscale against instances that are part of this stack

--- a/clouddriver-openstack/src/main/resources/asg_resource.yaml
+++ b/clouddriver-openstack/src/main/resources/asg_resource.yaml
@@ -1,6 +1,9 @@
 heat_template_version: 2016-04-08
 description: A load balanced server for Spinnaker.
 parameters:
+  disk_size:
+    type: number
+    description: Desired instance disk size, derived from the flavor
   flavor:
     type: string
     description: Flavor used by the servers.
@@ -26,8 +29,12 @@ resources:
   server:
     type: OS::Nova::Server
     properties:
+      block_device_mapping_v2:
+        - boot_index: 0
+          delete_on_termination: true
+          image_id: {get_param: image}
+          volume_size: {get_param: disk_size}
       flavor: {get_param: flavor}
-      image: {get_param: image}
       metadata: {get_param: metadata}
       networks:
         - subnet: {get_param: subnet_id}

--- a/clouddriver-openstack/src/main/resources/asg_server_resource.yaml
+++ b/clouddriver-openstack/src/main/resources/asg_server_resource.yaml
@@ -1,6 +1,9 @@
 heat_template_version: 2016-04-08
 description: An auto-scaled server for Spinnaker without any load balancer association.
 parameters:
+  disk_size:
+    type: number
+    description: Desired instance disk size, derived from the flavor
   flavor:
     type: string
     description: Flavor used by the servers.
@@ -26,8 +29,12 @@ resources:
   server:
     type: OS::Nova::Server
     properties:
+      block_device_mapping_v2:
+        - boot_index: 0
+          delete_on_termination: true
+          image_id: {get_param: image}
+          volume_size: {get_param: disk_size}
       flavor: {get_param: flavor}
-      image: {get_param: image}
       metadata: {get_param: metadata}
       networks:
         - subnet: {get_param: subnet_id}

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackOrchestrationV1ClientProviderSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/client/OpenstackOrchestrationV1ClientProviderSpec.groovy
@@ -66,7 +66,8 @@ class OpenstackOrchestrationV1ClientProviderSpec extends OpenstackClientProvider
       tags: ['foo':'bar'],
       sourceUserDataType: 'Text',
       sourceUserData: 'echo foobar',
-      asgResourceFilename: asgResourceFileName
+      asgResourceFilename: asgResourceFileName,
+      diskSize: 40
     )
     Map<String, String> params = [
       flavor               : parameters.instanceType,
@@ -91,7 +92,8 @@ class OpenstackOrchestrationV1ClientProviderSpec extends OpenstackClientProvider
       source_user_data     : 'echo foobar',
       tags                 : '{"foo":"bar"}',
       user_data            : parameters.rawUserData,
-      asg_resource_filename: asgResourceFileName
+      asg_resource_filename: asgResourceFileName,
+      disk_size            : '40'
     ]
     List<String> tags = loadBalancerIds.collect { "lb-${it}" }
     StackCreate stackCreate = Builders.stack().disableRollback(disableRollback).files(subtmpl).name(stackName).parameters(params).template(tmpl).timeoutMins(timeoutMins).tags(tags.join(',')).build()
@@ -345,7 +347,7 @@ class OpenstackOrchestrationV1ClientProviderSpec extends OpenstackClientProvider
     ServerGroupParameters parameters = new ServerGroupParameters(instanceType: instanceType, image: image,
       maxSize: maxSize, minSize: minSize, desiredSize: desiredSize, networkId: networkId, subnetId: subnetId,
       loadBalancers: loadBalancerIds, securityGroups: securityGroups, rawUserData: 'echo foobar', tags: ['foo':'bar'],
-      sourceUserDataType: 'Text', sourceUserData: 'echo foobar', asgResourceFilename: asgResourceFileName)
+      sourceUserDataType: 'Text', sourceUserData: 'echo foobar', asgResourceFilename: asgResourceFileName, diskSize: 40)
     Map<String, String> params = [
       flavor               : parameters.instanceType,
       image                : parameters.image,
@@ -369,7 +371,8 @@ class OpenstackOrchestrationV1ClientProviderSpec extends OpenstackClientProvider
       source_user_data     : 'echo foobar',
       tags                 : '{"foo":"bar"}',
       user_data            : parameters.rawUserData,
-      asg_resource_filename: asgResourceFileName
+      asg_resource_filename: asgResourceFileName,
+      disk_size            : '40'
     ]
     String template = "foo: bar"
     Map<String, String> subtmpl = [sub: "foo: bar"]

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/servergroup/ServerGroupParametersSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/description/servergroup/ServerGroupParametersSpec.groovy
@@ -87,7 +87,7 @@ class ServerGroupParametersSpec extends Specification {
       securityGroups: ["sg1"],
       autoscalingType: ServerGroupParameters.AutoscalingType.CPU,
       scaleup: scaleup, scaledown: scaledown, rawUserData: "echo foobar", tags: ["foo":"bar"],
-      sourceUserDataType: 'Text', sourceUserData: 'echo foobar', asgResourceFilename: 'asg_resource')
+      sourceUserDataType: 'Text', sourceUserData: 'echo foobar', asgResourceFilename: 'asg_resource', diskSize: 40)
   }
 
   @Ignore
@@ -96,7 +96,8 @@ class ServerGroupParametersSpec extends Specification {
      network_id:'net', subnet_id:'sub', load_balancers:'poop', security_groups:'sg1', autoscaling_type:'cpu_util',
      scaleup_cooldown:60, scaleup_adjustment:1, scaleup_period:60, scaleup_threshold:50,
      scaledown_cooldown:60, scaledown_adjustment:-1, scaledown_period:600, scaledown_threshold:15,
-     source_user_data_type:'Text', source_user_data:'echo foobar', tags: '{"foo":"bar"}', user_data:"echo foobar", asg_resource_filename: 'asg_resource']
+     source_user_data_type:'Text', source_user_data:'echo foobar', tags: '{"foo":"bar"}', user_data:"echo foobar",
+     asg_resource_filename: 'asg_resource', disk_size: '40']
   }
 
 }

--- a/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/DeployOpenstackAtomicOperationSpec.groovy
+++ b/clouddriver-openstack/src/test/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/DeployOpenstackAtomicOperationSpec.groovy
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackOpe
 import com.netflix.spinnaker.clouddriver.openstack.deploy.exception.OpenstackProviderException
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackCredentials
 import com.netflix.spinnaker.clouddriver.openstack.security.OpenstackNamedAccountCredentials
+import org.openstack4j.model.compute.Flavor
 import org.openstack4j.model.heat.Stack
 import org.openstack4j.model.network.Subnet
 import org.openstack4j.model.network.ext.ListenerV2
@@ -63,6 +64,7 @@ class DeployOpenstackAtomicOperationSpec extends Specification {
   def mockItem
   def mockSubnet
   def tags
+  def mockFlavor
 
   def setupSpec() {
     TaskRepository.threadLocalTask.set(Mock(Task))
@@ -87,6 +89,9 @@ class DeployOpenstackAtomicOperationSpec extends Specification {
     mockSubnet = Mock(Subnet)
     mockSubnet.networkId >> { '1234' }
     tags = [lbId]
+    mockFlavor = Mock(Flavor) {
+      it.name >> { 'name' }
+    }
   }
 
   def "should deploy a heat stack"() {
@@ -102,6 +107,7 @@ class DeployOpenstackAtomicOperationSpec extends Specification {
     1 * provider.getLoadBalancer(region, lbId) >> mockLb
     1 * provider.getListener(region, listenerId) >> mockListener
     1 * provider.getSubnet(region, subnetId) >> mockSubnet
+    1 * provider.getFlavor('region', 'm1.small') >> mockFlavor
     1 * provider.deploy(region, createdStackName, _ as String, _ as Map<String,String>, serverGroupParams, _ as Boolean, _ as Long, tags)
     noExceptionThrown()
   }
@@ -123,6 +129,7 @@ class DeployOpenstackAtomicOperationSpec extends Specification {
     1 * provider.getLoadBalancer(region, lbId) >> mockLb
     1 * provider.getListener(region, listenerId) >> mockListener
     1 * provider.getSubnet(region, subnetId) >> mockSubnet
+    1 * provider.getFlavor('region', 'm1.small') >> mockFlavor
     1 * provider.deploy(region, newStackName, _ as String, _ as Map<String,String>, serverGroupParams, _ as Boolean, _ as Long, tags)
     noExceptionThrown()
   }
@@ -151,6 +158,7 @@ class DeployOpenstackAtomicOperationSpec extends Specification {
     1 * provider.getLoadBalancer(region, lbId) >> mockLb
     1 * provider.getListener(region, listenerId) >> mockListener
     1 * provider.getSubnet(region, subnetId) >> mockSubnet
+    1 * provider.getFlavor('region', 'm1.small') >> mockFlavor
     1 * provider.deploy(region, createdStackName, _ as String, _ as Map<String,String>, scaledServerGroupParams, _ as Boolean, _ as Long, tags)
     noExceptionThrown()
   }
@@ -169,6 +177,7 @@ class DeployOpenstackAtomicOperationSpec extends Specification {
     1 * provider.getLoadBalancer(region, lbId) >> mockLb
     1 * provider.getListener(region, listenerId) >> mockListener
     1 * provider.getSubnet(region, subnetId) >> mockSubnet
+    1 * provider.getFlavor('region', 'm1.small') >> mockFlavor
     1 * provider.deploy(region, createdStackName, _ as String, _ as Map<String,String>, serverGroupParams, _ as Boolean, _ as Long, tags) >> { throw throwable }
     Throwable actual = thrown(OpenstackOperationException)
     actual.cause == throwable


### PR DESCRIPTION
This should be more efficient. As it stands, volumes are automatically used. I am wondering if this should be configurable, or if we can expect people to have cinder installed and want to use it.

@derekolk @varikin @pravka PTAL
