### PR TITLE
(Openstack) Do not base64 encode userdata.

### DIFF
--- a/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/DeployOpenstackAtomicOperation.groovy
+++ b/clouddriver-openstack/src/main/groovy/com/netflix/spinnaker/clouddriver/openstack/deploy/ops/servergroup/DeployOpenstackAtomicOperation.groovy
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.clouddriver.openstack.deploy.ops.StackPoolMemberAwa
 import com.netflix.spinnaker.clouddriver.openstack.domain.LoadBalancerResolver
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
+import groovy.util.logging.Slf4j
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.IOUtils
 import org.openstack4j.model.network.Subnet
@@ -50,6 +51,7 @@ import java.util.concurrent.ConcurrentHashMap
  * but again it would need to honor the expected parameters.
  * We could use the freeform details field to store the template string.
  */
+@Slf4j
 class DeployOpenstackAtomicOperation implements AtomicOperation<DeploymentResult>, StackPoolMemberAware, LoadBalancerResolver {
 
   private final String BASE_PHASE = "DEPLOY"
@@ -110,6 +112,7 @@ class DeployOpenstackAtomicOperation implements AtomicOperation<DeploymentResult
   DeploymentResult operate(List priorOutputs) {
     DeploymentResult deploymentResult = new DeploymentResult()
     try {
+      log.debug("Deploy Description: ${description}")
       task.updateStatus BASE_PHASE, "Initializing creation of server group..."
       OpenstackClientProvider provider = description.credentials.provider
 
@@ -179,7 +182,6 @@ class DeployOpenstackAtomicOperation implements AtomicOperation<DeploymentResult
         } else {
           userData = description.userData
         }
-        userData = Base64.encoder.encodeToString(userData.bytes)
         task.updateStatus BASE_PHASE, "Resolved user data."
       }
 

--- a/clouddriver-openstack/src/main/resources/asg_resource.yaml
+++ b/clouddriver-openstack/src/main/resources/asg_resource.yaml
@@ -21,7 +21,7 @@ parameters:
     description: Subnet used to allocate a fixed IP for each server.
   user_data:
     type: string
-    description: Raw base64-encoded string that will execute upon server boot, if cloud-init is installed.
+    description: String that will execute upon server boot, if cloud-init is installed.
 resources:
   server:
     type: OS::Nova::Server


### PR DESCRIPTION
Somewhere between Mitaka and cloud-init on the base image doesn't like
the base64 encoded userdata. It may be a configuration issue with
Mitaka or cloud-init (tested with v0.7.3) in the base image. We may need
to rethink this if there are problems in other environments.

Fixes spinnaker/spinnaker#1193
